### PR TITLE
docs: mention 'FILES' in usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ GitHub actions to get git diff.
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Screenshots
-1. Example workflow  
+1. Example workflow
    ![Example workflow](https://raw.githubusercontent.com/technote-space/get-diff-action/images/workflow.png)
-1. Skip  
+1. Skip
    ![Skip](https://raw.githubusercontent.com/technote-space/get-diff-action/images/skip.png)
 
 ## Usage
@@ -51,6 +51,9 @@ jobs:
             src
             __tests__
           SUFFIX_FILTER: .ts
+          FILES: |
+            yarn.lock
+            package.json
       - name: Install Package dependencies
         run: yarn install
         if: env.GIT_DIFF
@@ -107,7 +110,7 @@ If there is no difference in the source code below, this workflow will skip the 
    src/utils/command.ts
    yarn.lock
    ```
-   
+
    [${FROM}, ${TO}](#from-to)
 
 1. Filtered by `PREFIX_FILTER` or `SUFFIX_FILTER` option
@@ -123,9 +126,20 @@ If there is no difference in the source code below, this workflow will skip the 
    src/utils/command.ts
    ```
 
+1. Filtered by `FILES` option
+
+   e.g.
+   ```yaml
+   FILES: package-lock.json
+   ```
+   =>
+   ```
+   package.json
+   ```
+
 1. Mapped to absolute if `ABSOLUTE` option is true (default: false)
 
-   e.g. 
+   e.g.
    ```
    /home/runner/work/my-repo-name/my-repo-name/src/main.ts
    /home/runner/work/my-repo-name/my-repo-name/src/utils/command.ts
@@ -171,5 +185,5 @@ If called on any other event, the result will be empty.
 | else | context.payload.before | context.payload.after |
 
 ## Author
-[GitHub (Technote)](https://github.com/technote-space)  
+[GitHub (Technote)](https://github.com/technote-space)
 [Blog](https://technote.space)


### PR DESCRIPTION
Fixes #111

## Description: 概要
https://github.com/technote-space/get-diff-action/issues/111

## Changes: 変更内容
Mention the `FILES` option in the usage example

<!-- START pr-commits -->
<!-- END pr-commits -->

## Expected Impact: 影響範囲
Just the README

## Operating Requirements: 動作要件
n/a

## Additional context: 補足
I failed to notice that this was even possible, as a user, and thought I had to file an issue. 
